### PR TITLE
Upgrading WeasyPrint to v51

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gunicorn==19.9.0
-WeasyPrint==47
+WeasyPrint==51
 flask==1.0.1


### PR DESCRIPTION
This upgrade brings lots of bug fixes and better CSS Flexbox support.
I've tested the same template on both versions and there appears to be no issues.