### PR TITLE
Feature - accept content to render pdf by url

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,9 +47,16 @@ def home():
 @app.route('/pdf', methods=['POST'])
 def generate():
     name = request.args.get('filename', 'unnamed.pdf')
-    app.logger.info('POST  /pdf?filename=%s' % name)
-    #print ( request.get_data() )
-    html = HTML(string=request.get_data())
+    type = request.args.get('type', 'string')
+    app.logger.info('POST  /pdf?filename=%s&type=%s' % (name, type))
+    html = None
+    if type == 'string':
+        html = HTML(string=request.get_data())
+    elif type == 'url':
+        url_args = {'encoding': request.args.get('encoding',  None),
+                    'media_type': request.args.get('media_type', 'print'),
+                    'base_url': request.args.get('base_url', None)}
+        html = HTML(url=request.get_data().decode('UTF-8'), **url_args)
     pdf = html.write_pdf()
     response = make_response(pdf)
     response.headers['Content-Type'] = 'application/pdf'


### PR DESCRIPTION
Add ability to pass in the url argument to weasyprint.
Can set some of the additional url arguments, see [class weasyprint.HTML(input, **kwargs)](https://weasyprint.readthedocs.io/en/latest/api.html#weasyprint.HTML)

