### PR TITLE
fix(Dockerfile): on `Dockerfile` build failes on building of wheel for `Pillow`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:18.04
 #                        libpangocairo-1.0-0 \
 #    && apt-get -y clean
 
-RUN apt-get -y update && apt-get install -y build-essential python3-dev python3-pip python3-setuptools python3-wheel python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info
+RUN apt-get -y update && apt-get install -y build-essential python3-dev python3-pip python3-setuptools python3-wheel python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info libjpeg-dev zlib1g-dev
 
 ADD fonts /usr/share/fonts
 ADD requirements.txt /app/requirements.txt
@@ -31,6 +31,7 @@ ADD fonts.py /app/fonts.py
 ADD app.py /app/app.py
 WORKDIR /app
 
+RUN python3 -m pip install -U setuptools
 RUN python3 -m pip install -r requirements.txt
 
 EXPOSE 5001


### PR DESCRIPTION
When trying to build an image, on the step of installing `requirements.txt`, the installation fails for the Building wheel for `Pillow`

> Building wheels for collected packages: Pillow, cairocffi
> Running setup.py bdist_wheel for Pillow: started
> Running setup.py bdist_wheel for Pillow: finished with status 'error'