### PR TITLE
Upgrade base image and packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,45 @@
-FROM python:3.12
+FROM python:3.13-alpine
 
-#RUN echo "deb http://ftp.debian.org/debian stretch main contrib" > /etc/apt/sources.list
+# Install upgrades and dependancies for WeasyPrint
+RUN apk update && \
+    apk upgrade && \
+    apk add gcc \
+            musl-dev \
+            pango \
+            zlib-dev \
+            jpeg-dev \
+            openjpeg-dev \
+            g++ \
+            libffi-dev \
+            harfbuzz-subset
 
-# todo: Revert this entire pull request when libcairo2 >= 1.14.2 is available from the debian
-#       jessie repo.  This is a temporary fix for https://github.com/Kozea/WeasyPrint/issues/233
+# Install fonts
+RUN apk add font-terminus \
+            font-inconsolata \
+            font-dejavu \
+            font-noto \
+            font-noto-cjk \
+            font-awesome \
+            font-noto-extra \
+            font-vollkorn \
+            font-misc-cyrillic \
+            font-mutt-misc \
+            font-screen-cyrillic \
+            font-winitzki-cyrillic \
+            font-cronyx-cyrillic \
+            font-noto-thai \
+            font-noto-tibetan \
+            font-ipa \
+            font-sony-misc \
+            font-jis-misc \
+            font-isas-misc
 
-# reconfigure Debian to allow installs from both stretch (testing) repo and jessie (stable) repo
-# install all the dependencies except libcairo2 from jessie, then install libcairo2 from stretch
-
-#RUN apt-get -y update \
-#    && apt-get install -y \
-#        fonts-font-awesome \
-#        libffi-dev \
-#        libgdk-pixbuf2.0-0 \
-#        python-dev \
-#        python-lxml \
-#        shared-mime-info \
-#    && apt-get install -y ttf-mscorefonts-installer \
-#                        libpango1.0-0 \
-#                        libcairo2 \
-#                        libpangocairo-1.0-0 \
-#    && apt-get -y clean
-
-RUN apt-get -y update && apt-get install -y build-essential python3-dev python3-pip python3-setuptools python3-wheel python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info libjpeg-dev zlib1g-dev
-
+# Install custom fonts including BCSans
 ADD fonts /usr/share/fonts
-ADD requirements.txt /app/requirements.txt
 ADD fonts.py /app/fonts.py
 ADD app.py /app/app.py
+
+ADD requirements.txt /app/requirements.txt
 WORKDIR /app
 
 RUN python3 -m pip install -U setuptools
@@ -38,5 +50,4 @@ EXPOSE 5001
 ENV NUM_WORKERS=3
 ENV TIMEOUT=120
 
-#CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--timeout", "$TIMEOUT", "--workers", "$NUM_WORKERS", "wsgi:app"]
 CMD gunicorn --bind 0.0.0.0:5001 --timeout $TIMEOUT --workers $NUM_WORKERS  app:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gunicorn==22.0.0
-WeasyPrint==62.3
+gunicorn==23.0.0
+WeasyPrint==63.0
 flask==3.0.3


### PR DESCRIPTION
- Upgrade base image to python:3.13-alpine
  - Move to alpine for a more secure and compact image.
  - Upgrade to Python 3.13.x
- Add support for a wider variety of fonts and languages.

- Upgrade gunicorn to 23.0.0

- Upgrade WeasyPrint to 63.0